### PR TITLE
Creating the /dev/print group

### DIFF
--- a/rfc0003-dev_print-group.md
+++ b/rfc0003-dev_print-group.md
@@ -1,0 +1,37 @@
+
+**Linux User's Group at University of Illinois Chicago**
+
+**Request for Comment:** #0003
+
+&nbsp;&nbsp;&nbsp;&nbsp;Relevant RFCs: #0000
+
+**Category:** Experimental
+
+-------------------------------------------------------------------------------------------------------------------------
+
+Anthony Phelps
+
+UIC
+
+<center>The /dev/print User Group</center>
+
+**Abstract:**
+
+This document lays out the structure of the /dev/print User Group of the Linux User's Group at the University of Illinois at Chicago. This user group exists to discuss and administer the LUG's 3D Printer and it's related assets.
+
+**Copyright and License Notice:**
+
+This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/4.0/.
+
+**Table of Contents:**
+
+# Purpose
+
+The purpose of this group is to discuss and administer the LUG 3D Printer, 3D Scanner, and Kinect.
+
+# Governance
+
+This group shall be run by a Head Printer Admin who will be decided by a majority vote of the group members. The newly voted Head Printer Admin must be approved by a vote of the Traditional Officers on behalf of the Executive Committee. The Head Printer Admin will then appoint at least two Printer Admins to work under him. These admins should have a strong working knowledge of the 3D Printing equipment owned by the LUG.
+
+The Printer Admins are in charge of maintaining and running all 3D printing related opertions.
+


### PR DESCRIPTION
The /dev/print group exists to manage the LUG 3D printer and its associated equipment. As well as handle educating interested members about the printer.