### PR TITLE
Create the /usr/share/dict group

### DIFF
--- a/rfc0005-usr_share_dict-group.md
+++ b/rfc0005-usr_share_dict-group.md
@@ -1,0 +1,33 @@
+**Linux User's Group at University of Illinois Chicago**
+
+**Request for Comment:** #0005
+
+&nbsp;&nbsp;&nbsp;&nbsp;Relevant RFCs: #0000
+
+**Category:** Experimental
+
+-------------------------------------------------------------------------------------------------------------------------
+
+Anthony Phelps
+
+UIC
+
+<center>The root User Group</center>
+
+**Abstract:**
+
+This document lays out the structure of the /usr/share/dict User Group of the Linux User's Group at the University of Illinois at Chicago. This group exists to give LUG members a place to learn and explore new programming languages and concepts that will not necessarily be encountered in classes.
+
+**Copyright and License Notice:**
+
+This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/4.0/.
+
+**Table of Contents:**
+
+# Purpose
+
+This group exists to give LUG members a place to learn and explore new programming languages and concepts that will not necessarily be encountered in classes. The main goal should be to learn a programming language that is in some way conceptualy different from he standard languages learned in classes at UIC. 
+
+# Governance
+
+This group shall be run by a council of all it's members. All decisions will be made by a majority vote of members present when the vote is called.


### PR DESCRIPTION
This group exists to teach interested members new programming languages and concepts not common in the university's curriculum.